### PR TITLE
Add AUMID for HoloLens 2 Device Picker

### DIFF
--- a/hololens/hololens-kiosk.md
+++ b/hololens/hololens-kiosk.md
@@ -94,7 +94,8 @@ If you use a Mobile Device Management (MDM) system or a provisioning package to 
 |Calendar |microsoft.windowscommunicationsapps\_8wekyb3d8bbwe\!microsoft.windowslive.calendar |
 |Camera<sup>1, 2</sup> |HoloCamera\_cw5n1h2txyewy\!HoloCamera |
 |Cortana<sup>3</sup> |Microsoft.549981C3F5F10\_8wekyb3d8bbwe\!App |
-|Device Picker |HoloDevicesFlow\_cw5n1h2txyewy\!HoloDevicesFlow |
+|Device Picker on HoloLens (1st gen) |HoloDevicesFlow\_cw5n1h2txyewy\!HoloDevicesFlow |
+|Device Picker on HoloLens 2 |Microsoft.Windows.DevicesFlowHost\_cw5n1h2txyewy\!Microsoft.Windows.DevicesFlowHost |
 |Dynamics 365 Guides |Microsoft.Dynamics365.Guides\_8wekyb3d8bbwe\!MicrosoftGuides |
 |Dynamics 365 Remote Assist |Microsoft.MicrosoftRemoteAssist\_8wekyb3d8bbwe\!Microsoft.RemoteAssist |
 |Feedback&nbsp;Hub |Microsoft.WindowsFeedbackHub\_8wekyb3d8bbwe\!App |


### PR DESCRIPTION
HoloLens (1st gen) and HoloLens 2 use different apps for their device pickers.  This updates the kiosk mode documentation to list the correct AUMID for HoloLens 2.