### PR TITLE
Update security-encryption-data-protection.md

### DIFF
--- a/hololens/security-encryption-data-protection.md
+++ b/hololens/security-encryption-data-protection.md
@@ -25,7 +25,7 @@ BitLocker is a full-volume encryption feature for integrity protection of Read O
 
 BDE is a data protection feature that employs AES-XTS-256 encryption on all volumes in the state-separated layout of the device. BDE provides device level encryption in a state-separated layout. BitLocker Device Encryption is enabled automatically on operating system and fixed data volumes and cannot be turned off, even by IT administrators, so that the device is always protected.
 
-BDE encryption keys are then used to transparently decrypt binaries and the data required to boot the device. As the operating system volume is unlocked and a system is booting up, other volumes become accessible using a volume-specific version of the auto-unlock protector. No other protectors are available to maintain user privacy and the drive can only be unlocked on the same device. Read Only (RO) enforcement on required volumes is applied and enforced immediately, starting from the first boot.
+BDE encryption keys are then used to transparently decrypt binaries and the data required to boot the device. As the operating system volume is unlocked and a system is booting up, other volumes become accessible using a volume-specific version of the auto-unlock protector. No other protectors are available to maintain user privacy and the drive can only be unlocked on the same device. Read Only (RO) enforcement on required volumes is applied and enforced immediately, starting from the first boot. The Bitlocker recovery key is not needed in the HoloLens 2 lifecycle.
 
 ## Azure integration 
 


### PR DESCRIPTION
Added a sentence to highlight that the Bitlocker recovery key is not needed in the HoloLens 2 lifecycle. This is important for an administrator to understand in their planning activities.