### PR TITLE
TOC updated - Segregate HL1 content from HL2

### DIFF
--- a/hololens/TOC.md
+++ b/hololens/TOC.md
@@ -1,5 +1,16 @@
 # [Microsoft HoloLens](index.yml)
 
+## Get started with HoloLens (1st gen)
+### [HoloLens (1st gen) hardware](hololens1-hardware.md)
+### [Get your HoloLens (1st gen) ready to use](hololens1-setup.md)
+### [Set up your HoloLens (1st gen)](hololens1-start.md)
+### [HoloLens (1st gen) fit and comfort FAQ](hololens1-fit-comfort-faq.md)
+### [Install localized version of HoloLens (1st gen)](hololens1-install-localized.md)
+### [Getting around HoloLens (1st gen)](hololens1-basic-usage.md)
+### [Use the HoloLens (1st gen) clicker](hololens1-clicker.md)
+### [Use 3D Viewer on HoloLens (1st gen)](holographic-3d-viewer-beta.md)
+### [Manage custom apps for HoloLens](holographic-custom-apps.md)
+
 # Overview
 
 ## Get started with HoloLens 2
@@ -15,18 +26,6 @@
 ### [HoloLens 2 Development Edition FAQ](hololens2-development-edition-faq.md)
 ### [HoloLens 2 Industrial Edition FAQ](hololens2-industrial-edition-faq.md)
 
-
-
-## Get started with HoloLens (1st gen)
-### [HoloLens (1st gen) hardware](hololens1-hardware.md)
-### [Get your HoloLens (1st gen) ready to use](hololens1-setup.md)
-### [Set up your HoloLens (1st gen)](hololens1-start.md)
-### [HoloLens (1st gen) fit and comfort FAQ](hololens1-fit-comfort-faq.md)
-### [Install localized version of HoloLens (1st gen)](hololens1-install-localized.md)
-### [Getting around HoloLens (1st gen)](hololens1-basic-usage.md)
-### [Use the HoloLens (1st gen) clicker](hololens1-clicker.md)
-### [Use 3D Viewer on HoloLens (1st gen)](holographic-3d-viewer-beta.md)
-### [Manage custom apps for HoloLens](holographic-custom-apps.md)
 
 
 ## Navigate the Windows Holographic interface


### PR DESCRIPTION
Separating out HL1 content from the TOC sub-element and bring this to the top as this page should focus on HL2 only.