### PR TITLE
Update visitor autologon docs

### DIFF
--- a/hololens/hololens-kiosk.md
+++ b/hololens/hololens-kiosk.md
@@ -121,6 +121,10 @@ Here are the following ways to configure, select the tab matching the process yo
 
 ### How can visitor accounts automatically logon to kiosk experience?
 
+By default devices configured for kiosk mode with visitor accounts will have a button on the sign-in screen that will logon a visitor with a single tap. Once logged on, the device will not show the sign-in screen again until the visitor is explicitly signed out from the start menu or the device is restarted. However sometimes you may want to set up the device such that the sign-in screen is never shown and for the device to automatically logon using a visitor account to the kiosk experience. To do this, configure the [MixedReality/VisitorAutoLogon](/windows/client-management/mdm/policy-csp-mixedreality#mixedreality-visitorautologon) policy.
+
+A device configured to automatically logon using a visitor account will not have on-device UI to exit this mode. To ensure that a device isn't accidentally locked out,  this policy requires that no other user accounts are present on the device. As a result, this policy must be applied during device setup either by using a provisioning package or by MDM using Autopilot.
+
 On builds [Windows Holographic, version 21H1](hololens-release-notes.md#windows-holographic-version-21h1) and onwards:
 
 - Azure AD and Non-Azure AD configurations both support visitor accounts being autologon enabled for Kiosk modes.

--- a/hololens/includes/kiosk-autologin.md
+++ b/hololens/includes/kiosk-autologin.md
@@ -1,23 +1,24 @@
-# [Non-AAD configuration](#tab/nonaadlogon)
+# [Autopilot with MDM](#tab/autopilot)
 
-#### Non-AAD configuration
+#### Autopilot with MDM
 
-1. Create a provisioning package that:
-    1. Configures Runtime settings/AssignedAccess to allow Visitor accounts.
-    1. Optionally enrolls the device in MDM (Runtime settings/Workplace/Enrollments) so that it can be managed later.
-    1. Do not create a local account
-2. [Apply the provisioning package](../hololens-provisioning.md).
+Visitor Auto logon can be managed via [custom OMA-URI policy](/mem/intune/configuration/custom-settings-windows-10).
 
-# [AAD configuration](#tab/aadlogon)
-
-#### AAD configuration
-
-AAD joined devices configured for kiosk mode can sign in a Visitor account with a single button tap from the sign-in screen. Once signed in to the visitor account, the device will not prompt for sign-in again until the Visitor is explicitly signed out from the start menu or the device is restarted.
-
-Visitor Auto logon can be managed via [custom OMA-URI policy](/mem/intune/configuration/custom-settings-windows-10):
-
-- URI value: ./Device/Vendor/MSFT/MixedReality/VisitorAutoLogon
+- URI value: ./Device/Vendor/MSFT/Policy/Config/MixedReality/VisitorAutoLogon
 
 | Policy | Description | Configurations |
 | --------------------------- | ------------- | -------------------- |
 | MixedReality/VisitorAutoLogon | Allows for a Visitor to Auto logon to a Kiosk. | 1 (Yes), 0 (No, default.) |
+
+For details, see the Policy CSP page for [MixedReality/VisitorAutoLogon](/windows/client-management/mdm/policy-csp-mixedreality#mixedreality-visitorautologon).
+
+# [Provisioning Package](#tab/provisioning)
+
+#### Provisioning Package
+
+1. Create a provisioning package that:
+    1. Configures **Runtime settings/Policies/MixedReality/VisitorAutoLogon** to allow Visitor accounts.
+    2. Optionally enrolls the device in MDM (**Runtime settings/Workplace/Enrollments**) so that it can be managed later.
+    3. Do not create a local account
+2. [Apply the provisioning package](../hololens-provisioning.md).
+


### PR DESCRIPTION
This change updates the visitor autologon docs.
- Describes why someone would want to use visitor autologon
- Fixes the visitor autologon OMA-URI path and provisioning setting path in WCD
- Renames Non-AAD/AAD to Provisioning Package/MDM